### PR TITLE
Updated version and SHA for v5.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.0.3" %}
+{% set version = "5.1.0" %}
 
 package:
   name: qtconsole
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/q/qtconsole/qtconsole-{{ version }}.tar.gz
-  sha256: c091a35607d2a2432e004c4a112d241ce908086570cf68594176dd52ccaa212d
+  sha256: 12c734494901658787339dea9bbd82f3dc0d5e394071377a1c77b4a0954d7d8b
 
 build:
   noarch: python
@@ -29,6 +29,7 @@ requirements:
     - pygments
     - ipykernel >=4.1  # not a real dependency, but require the reference kernel
     - qtpy
+    - pyzmq >=17.1
 
 app:
   entry: jupyter-qtconsole
@@ -47,6 +48,7 @@ test:
 about:
   home: http://jupyter.org
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: Jupyter Qt console
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - python >=3.6
     - pip
+    - wheel
+    - setuptools
   run:
     - python >=3.6
     - pyqt


### PR DESCRIPTION
Actions:
Updated version and SHA for v5.1.0 in meta.yaml.
Added wheel and setuptools



Category: anaconda
Version change: bump from 5.0.3 to 5.1.0
Changelog: https://github.com/jupyter/qtconsole/blob/master/docs/source/changelog.rst
Upstream Issues: https://github.com/jupyter/qtconsole/issues
Requirements https://github.com/jupyter/qtconsole/blob/master/setup.py
License : https://github.com/jupyter/qtconsole/blob/master/LICENSE
The package builds correctly on concourse.
