### PR TITLE
qtconsole: update from 5.1.0 to 5.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,11 @@ app:
   type: desk
 
 test:
+  requires:
+    - pip
+
   commands:
+    - pip check
     - jupyter qtconsole --help                                              # [win]
     - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'  # [linux and not aarch64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter-qtconsole = qtconsole.qtconsoleapp:main
-  skip: true  # [s390x and ppc64le]
+  skip: true  # [s390x or ppc64le]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter-qtconsole = qtconsole.qtconsoleapp:main
+  skip: true  # [s390x and ppc64le]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.1.0" %}
+{% set version = "5.1.1" %}
 
 package:
   name: qtconsole
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/q/qtconsole/qtconsole-{{ version }}.tar.gz
-  sha256: 12c734494901658787339dea9bbd82f3dc0d5e394071377a1c77b4a0954d7d8b
+  sha256: bbc34bca14f65535afcb401bc74b752bac955e5313001ba640383f7e5857dc49
 
 build:
   noarch: python


### PR DESCRIPTION
* [x] upstream repo https://github.com/jupyter/qtconsole
* [x] run tests on dependent packages
  * no dependent packages
* [x] go through [changelog](https://github.com/jupyter/qtconsole/blob/master/docs/source/changelog.rst)
  * Improve handling of different keyboard combinations.
  * Move cursor to the beginning of buffer if on the same line.
* [x] look for any open issues for new versions
* [x] dev_url, doc_url valid
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream github setup
```
meta.yaml
    - python >=3.6
    - jupyter_client >=4.1
    - ipykernel >=4.1  # not a real dependency, but require the reference kernel
    - pyzmq >=17.1
setup.py
    python_requires               = '>= 3.6',
        'Programming Language :: Python :: 3',
        'Programming Language :: Python :: 3.6',
        'Programming Language :: Python :: 3.7',
        'Programming Language :: Python :: 3.8',
        'Programming Language :: Python :: 3.9',
        'jupyter_client>=4.1',
        'ipykernel>=4.1', # not a real dependency, but require the reference kernel
        'pyzmq>=17.1'
```