### PR TITLE
qtconsole 5.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "5.2.2" %}
 
 package:
-  name: {{ name|lower }}-base
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
@@ -31,6 +31,7 @@ requirements:
     - jupyter_client >=4.1
     - jupyter_core
     - pygments
+    - pyqt
     - pyzmq >=17.1
     - qtpy
     - traitlets
@@ -44,26 +45,13 @@ test:
   imports:
     - qtconsole
     - qtconsole.tests
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    - pip check
+    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx)]
 
-outputs:
-  - name: qtconsole-base
-  - name: qtconsole
-    build:
-      noarch: python
-    requirements:
-      host:
-        - python
-      run:
-        - python >=3.6
-        - {{ pin_subpackage('qtconsole-base', max_pin='x.x.x') }}
-        - pyqt
-    test:
-      requires:
-        - pip
-        - python <3.10
-      commands:
-        - pip check
-        - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx)]
 about:
   home: http://jupyter.org
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,7 +63,7 @@ outputs:
         - python <3.10
       commands:
         - pip check
-        - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
+        - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx)]
 about:
   home: http://jupyter.org
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "5.2.2" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}-base
   version: {{ version }}
 
 source:
@@ -31,7 +31,6 @@ requirements:
     - jupyter_client >=4.1
     - jupyter_core
     - pygments
-    - pyqt
     - pyzmq >=17.1
     - qtpy
     - traitlets
@@ -45,14 +44,26 @@ test:
   imports:
     - qtconsole
     - qtconsole.tests
-  requires:
-    - pip
-    - python <3.10
-  commands:
-    - pip check
-    - jupyter qtconsole --help  
-    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
 
+outputs:
+  - name: qtconsole-base
+  - name: qtconsole
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python >=3.6
+        - {{ pin_subpackage('qtconsole-base', max_pin='x.x.x') }}
+        - pyqt
+    test:
+      requires:
+        - pip
+        - python <3.10
+      commands:
+        - pip check
+        - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
 about:
   home: http://jupyter.org
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,31 @@
+{% set name = "qtconsole" %}
 {% set version = "5.2.2" %}
 
 package:
-  name: qtconsole
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/q/qtconsole/qtconsole-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/qtconsole-{{ version }}.tar.gz
   sha256: 8f9db97b27782184efd0a0f2d57ea3bd852d053747a2e442a9011329c082976d
 
 build:
   noarch: python
   number: 0
+  # Not available on s390x, ppc64le due to missing qt.
+  skip: true  # [s390x or ppc64le]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter-qtconsole = qtconsole.qtconsoleapp:main
-  skip: true  # [s390x or ppc64le]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - wheel
     - setuptools
   run:
     - python >=3.6
-    - pyqt
     - traitlets
     - ipython_genutils
     - jupyter_core
@@ -40,17 +41,30 @@ app:
   type: desk
 
 test:
-  requires:
-    - pip
-
-  commands:
-    - pip check
-    - jupyter qtconsole --help                                              # [win]
-    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'  # [linux and not aarch64]
-
   imports:
     - qtconsole
     - qtconsole.tests
+
+outputs:
+  - name: qtconsole-base
+  - name: qtconsole
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python >=3.6
+        - {{ pin_subpackage('qtconsole-base', max_pin='x.x.x') }}
+        - pyqt
+    test:
+      requires:
+        - pip
+        - python <3.10
+      commands:
+        - pip check
+        - jupyter qtconsole --help  
+        - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
 
 about:
   home: http://jupyter.org
@@ -67,7 +81,7 @@ about:
     more.
   doc_url: https://qtconsole.readthedocs.org/en/stable/
   dev_url: https://github.com/jupyter/qtconsole
-  doc_source_url: https://github.com/jupyter/qtconsole/tree/master/docs
+  doc_source_url: https://github.com/jupyter/qtconsole/tree/{{ version }}/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ test:
     - qtconsole
     - qtconsole.tests
   requires:
+    - pip
     - python <3.10
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,17 @@ requirements:
     - pip
     - wheel
     - setuptools
+  run:
+    - python >=3.6
+    - ipykernel >=4.1  # not a real dependency, but require the reference kernel
+    - ipython_genutils
+    - jupyter_client >=4.1
+    - jupyter_core
+    - pygments
+    - pyqt
+    - pyzmq >=17.1
+    - qtpy
+    - traitlets
 
 app:
   entry: jupyter-qtconsole
@@ -34,46 +45,12 @@ test:
   imports:
     - qtconsole
     - qtconsole.tests
-
-outputs:
-  - name: qtconsole-base
-      build:
-      noarch: python
-    requirements:
-      host:
-        - python
-      run:
-        - python >=3.6
-        - traitlets
-        - ipython_genutils
-        - jupyter_core
-        - jupyter_client >=4.1
-        - pygments
-        - ipykernel >=4.1  # not a real dependency, but require the reference kernel
-        - qtpy
-        - pyzmq >=17.1
-    test:
-      requires:
-        - python <3.10
-
-  - name: qtconsole
-    build:
-      noarch: python
-    requirements:
-      host:
-        - python
-      run:
-        - python >=3.6
-        - {{ pin_subpackage('qtconsole-base', max_pin='x.x.x') }}
-        - pyqt
-    test:
-      requires:
-        - pip
-        - python <3.10
-      commands:
-        - pip check
-        - jupyter qtconsole --help  
-        - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
+  requires:
+    - python <3.10
+  commands:
+    - pip check
+    - jupyter qtconsole --help  
+    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
 
 about:
   home: http://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,16 +24,6 @@ requirements:
     - pip
     - wheel
     - setuptools
-  run:
-    - python >=3.6
-    - traitlets
-    - ipython_genutils
-    - jupyter_core
-    - jupyter_client >=4.1
-    - pygments
-    - ipykernel >=4.1  # not a real dependency, but require the reference kernel
-    - qtpy
-    - pyzmq >=17.1
 
 app:
   entry: jupyter-qtconsole
@@ -47,6 +37,25 @@ test:
 
 outputs:
   - name: qtconsole-base
+      build:
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python >=3.6
+        - traitlets
+        - ipython_genutils
+        - jupyter_core
+        - jupyter_client >=4.1
+        - pygments
+        - ipykernel >=4.1  # not a real dependency, but require the reference kernel
+        - qtpy
+        - pyzmq >=17.1
+    test:
+      requires:
+        - python <3.10
+
   - name: qtconsole
     build:
       noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.1.1" %}
+{% set version = "5.2.2" %}
 
 package:
   name: qtconsole
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/q/qtconsole/qtconsole-{{ version }}.tar.gz
-  sha256: bbc34bca14f65535afcb401bc74b752bac955e5313001ba640383f7e5857dc49
+  sha256: 8f9db97b27782184efd0a0f2d57ea3bd852d053747a2e442a9011329c082976d
 
 build:
   noarch: python


### PR DESCRIPTION
Update qtconsole to 5.2.2

Changelog: https://qtconsole.readthedocs.io/en/stable/changelog.html
License: https://github.com/jupyter/qtconsole/blob/5.2.2/LICENSE
Upstream setup file: https://github.com/jupyter/qtconsole/blob/5.2.2/setup.py
Upstream requirements: https://github.com/jupyter/qtconsole/blob/5.2.2/requirements/environment.yml


