### PR TITLE
qtconsole 5.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
+  skip: True  # [ppc64le or s390x or (py==310 and (osx or aarch64))]
   # Not available on s390x, ppc64le due to missing qt.
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,9 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
-  skip: True  # [ppc64le or s390x or (py==310 and (osx or aarch64))]
   # Not available on s390x, ppc64le due to missing qt.
+  # Not available on osx and aarch64 for python 3.10 due to missing pyqt.
+  skip: True  # [ppc64le or s390x or (py==310 and (osx or aarch64))]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter-qtconsole = qtconsole.qtconsoleapp:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ test:
     - pip
   commands:
     - pip check
-    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx)]
+    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "qtconsole" %}
-{% set version = "5.3.0" %}
+{% set version = "5.3.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/qtconsole-{{ version }}.tar.gz
-  sha256: 8e3520fdc75e46abc4cc6cffeca16fa2652754109b8ae839fa28e27d1eba5625
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b73723fac43938b684dcb237a88510dc7721c43a726cea8ade179a2927c0a2f3
 
 build:
-  noarch: python
   number: 0
+  skip: True  # [py<37]
   # Not available on s390x, ppc64le due to missing qt.
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -24,7 +24,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3.7
+    - python
     - ipykernel >=4.1  # not a real dependency, but require the reference kernel
     - ipython_genutils
     - jupyter_client >=4.1
@@ -33,7 +33,7 @@ requirements:
     - pyqt
     - pyzmq >=17.1
     - qtpy >=2.0.1
-    - traitlets
+    - traitlets !=5.2.1,!=5.2.2
 
 app:
   entry: jupyter-qtconsole
@@ -51,7 +51,7 @@ test:
     - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx)]
 
 about:
-  home: http://jupyter.org
+  home: https://jupyter.org
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE


### PR DESCRIPTION
Update qtconsole to 5.3.1

Changelog: https://qtconsole.readthedocs.io/en/stable/changelog.html
License: https://github.com/jupyter/qtconsole/blob/5.3.1/LICENSE
Upstream setup file: https://github.com/jupyter/qtconsole/blob/5.3.1/setup.py
Upstream requirements: https://github.com/jupyter/qtconsole/blob/5.3.1/requirements/environment.yml

Actions:
1. Remove `noarch: python`
2. Skip `py<37`
3. Skip `ppc64le` or `s390x` or `(py==310 and (osx or aarch64))` because of missing **pyqt**
4. Fix python in run
5. Fix `traitlets` pinning
6. Fix home url