### PR TITLE
Rebuild for osx and aarch64 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: b73723fac43938b684dcb237a88510dc7721c43a726cea8ade179a2927c0a2f3
 
 build:
-  number: 0
-  # Trugger 1
+  number: 1
   skip: True  # [py<37]
   # Not available on s390x, ppc64le due to missing qt.
   skip: True  # [ppc64le or s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,10 +49,7 @@ test:
     - pip
   commands:
     - pip check
-    # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
-    # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
-    # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
-    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
+    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,10 @@ test:
     - pip
   commands:
     - pip check
-    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
+    # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
+    # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
+    # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
+    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,7 @@ build:
   # Trugger 1
   skip: True  # [py<37]
   # Not available on s390x, ppc64le due to missing qt.
-  # Not available on osx and aarch64 for python 3.10 due to missing pyqt.
-  skip: True  # [ppc64le or s390x or (py==310 and (osx or aarch64))]
+  skip: True  # [ppc64le or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter-qtconsole = qtconsole.qtconsoleapp:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  # Trugger 1
   skip: True  # [py<37]
   # Not available on s390x, ppc64le due to missing qt.
   # Not available on osx and aarch64 for python 3.10 due to missing pyqt.


### PR DESCRIPTION
Actions:
1. Drop  skipping for `(py==310 and (osx or aarch64)` as **pyqt 5.15.7** is available on those platforms
2. Disable `- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]`, because:
```
Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
```