### PR TITLE
qtconsole 5.3.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,7 @@ test:
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
     #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
+    - jupyter qtconsole --help  # [win or osx]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,10 @@ test:
     - pip
   commands:
     - pip check
-    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
+    # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
+    # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
+    # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
+    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtconsole" %}
-{% set version = "5.3.1" %}
+{% set version = "5.3.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b73723fac43938b684dcb237a88510dc7721c43a726cea8ade179a2927c0a2f3
+  sha256: 8eadf012e83ab018295803c247c6ab7eacd3d5ab1e1d88a0f37fdcfdab9295a3
 
 build:
-  number: 1
+  number: 0
   skip: True  # [py<37]
   # Not available on s390x, ppc64le due to missing qt.
   skip: True  # [ppc64le or s390x]
@@ -49,10 +49,7 @@ test:
     - pip
   commands:
     - pip check
-    # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
-    # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
-    # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
-    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
+    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
 
 about:
   home: https://jupyter.org


### PR DESCRIPTION
Changelog: https://qtconsole.readthedocs.io/en/stable/changelog.html
License: https://github.com/jupyter/qtconsole/blob/5.3.2/LICENSE
Upstream setup file: https://github.com/jupyter/qtconsole/blob/5.3.2/setup.py
Upstream requirements: https://github.com/jupyter/qtconsole/blob/5.3.2/requirements/environment.yml

Actions:
1. Reset build number