### PR TITLE
qtconsole 5.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pyqt
     - pyzmq >=17.1
     - qtpy >=2.0.1
-    - traitlets !=5.2.1,!=5.2.2
+    - traitlets !=5.2.1, !=5.2.2  # Skip traitlets versions that break Qtconsole on Windows
 
 app:
   entry: jupyter-qtconsole
@@ -60,6 +60,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
+  license_url: https://github.com/jupyter/qtconsole/blob/master/LICENSE
   summary: Jupyter Qt console
   description: |
     A rich Qt-based console for working with Jupyter kernels, supporting rich


### PR DESCRIPTION
Changelog: https://qtconsole.readthedocs.io/en/stable/changelog.html
License: https://github.com/jupyter/qtconsole/blob/5.3.2/LICENSE
Upstream setup file: https://github.com/jupyter/qtconsole/blob/5.3.2/setup.py
Upstream requirements: https://github.com/jupyter/qtconsole/blob/5.3.2/requirements/environment.yml

Actions:
1. Reset build number
2. Add license_url
3. Add a comment about traitlets