### PR TITLE
Update 5.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
-    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
+    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,6 @@ test:
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
     - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
-    - jupyter qtconsole --help  # [win or osx]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - jupyter_core
     - jupyter_client >=4.1
     - pygments
-    - pyqt  # not a dependency listed in setup.py but is still a runtime requirement for pyqt https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
+    - pyqt  # not a dependency listed in setup.py but is still a runtime requirement for qtconsole https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
     - pyzmq>=17.1
     - qtpy >=2.0.1
     - traitlets !=5.2.1, !=5.2.2  # Skip traitlets versions that break Qtconsole on Windows

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,12 +27,13 @@ requirements:
   run:
     - python
     - ipython_genutils
+    - ipykernel >=4.1  # not a real dependency, but require the reference kernel
     - jupyter_core
     - jupyter_client >=4.1
     - pygments
-    - ipykernel >=4.1  # not a real dependency, but require the reference kernel
-    - qtpy >=2.0.1
     - pyqt  # not a dependency listed in setup.py but is still a runtime requirement for pyqt https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
+    - pyzmq>=17.1
+    - qtpy >=2.0.1
 
 app:
   entry: jupyter-qtconsole

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtconsole" %}
-{% set version = "5.3.1" %}
+{% set version = "5.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b73723fac43938b684dcb237a88510dc7721c43a726cea8ade179a2927c0a2f3
+  sha256: 57748ea2fd26320a0b77adba20131cfbb13818c7c96d83fafcb110ff55f58b35
 
 build:
-  number: 1
+  number: 0
   skip: True  # [py<37]
   # Not available on s390x, ppc64le due to missing qt.
   skip: True  # [ppc64le or s390x]
@@ -26,15 +26,13 @@ requirements:
     - setuptools
   run:
     - python
-    - ipykernel >=4.1  # not a real dependency, but require the reference kernel
+    - traitlets
     - ipython_genutils
-    - jupyter_client >=4.1
     - jupyter_core
+    - jupyter_client >=4.1
     - pygments
-    - pyqt
-    - pyzmq >=17.1
+    - ipykernel >=4.1  # not a real dependency, but require the reference kernel
     - qtpy >=2.0.1
-    - traitlets !=5.2.1,!=5.2.2
 
 app:
   entry: jupyter-qtconsole

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - pyqt  # not a dependency listed in setup.py but is still a runtime requirement for pyqt https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
     - pyzmq>=17.1
     - qtpy >=2.0.1
+    - traitlets !=5.2.1, !=5.2.2  # Skip traitlets versions that break Qtconsole on Windows
 
 app:
   entry: jupyter-qtconsole

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - setuptools
   run:
     - python
-    - traitlets !=5.2.1,!=5.2.2'
+    - traitlets
     - ipython_genutils
     - jupyter_core
     - jupyter_client >=4.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: b73723fac43938b684dcb237a88510dc7721c43a726cea8ade179a2927c0a2f3
 
 build:
-  number: 0
-  # Trugger 1
+  number: 1
   skip: True  # [py<37]
   # Not available on s390x, ppc64le due to missing qt.
   skip: True  # [ppc64le or s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,10 +49,7 @@ test:
     - pip
   commands:
     - pip check
-    # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
-    # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
-    # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
-    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
+    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,10 @@ test:
     - pip
   commands:
     - pip check
-    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
+    # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
+    # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
+    # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
+    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - pygments
     - ipykernel >=4.1  # not a real dependency, but require the reference kernel
     - qtpy >=2.0.1
+    - pyqt  # not a dependency but is still required for install as qt depends on pyqt https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
 
 app:
   entry: jupyter-qtconsole

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,7 @@ build:
   # Trugger 1
   skip: True  # [py<37]
   # Not available on s390x, ppc64le due to missing qt.
-  # Not available on osx and aarch64 for python 3.10 due to missing pyqt.
-  skip: True  # [ppc64le or s390x or (py==310 and (osx or aarch64))]
+  skip: True  # [ppc64le or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter-qtconsole = qtconsole.qtconsoleapp:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - setuptools
   run:
     - python
-    - traitlets
+    - traitlets !=5.2.1,!=5.2.2'
     - ipython_genutils
     - jupyter_core
     - jupyter_client >=4.1
@@ -50,8 +50,9 @@ test:
     # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
-    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
-
+    # - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
+    - jupyter-qtconsole = qtconsole.qtconsoleapp:main
+  
 about:
   home: https://jupyter.org
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
-    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
+    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help' # [not ((linux and aarch64) or osx or win)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  # Trugger 1
   skip: True  # [py<37]
   # Not available on s390x, ppc64le due to missing qt.
   # Not available on osx and aarch64 for python 3.10 due to missing pyqt.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,14 +26,13 @@ requirements:
     - setuptools
   run:
     - python
-    - traitlets
     - ipython_genutils
     - jupyter_core
     - jupyter_client >=4.1
     - pygments
     - ipykernel >=4.1  # not a real dependency, but require the reference kernel
     - qtpy >=2.0.1
-    - pyqt  # not a dependency but is still required for install as qt depends on pyqt https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
+    - pyqt  # not a dependency listed in setup.py but is still a runtime requirement for pyqt https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
 
 app:
   entry: jupyter-qtconsole

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,8 @@ test:
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
     # - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
-    - jupyter-qtconsole = qtconsole.qtconsoleapp:main
-  
+    - jupyter qtconsole --help  # [win or osx]
+
 about:
   home: https://jupyter.org
   license: BSD-3-Clause


### PR DESCRIPTION
## Version Bump to 5.4.0
- updated checksum and version number
- added clarification on dependency `pyqt ` not being listed in setup.py but is still a runtime requirement for `qtconsole`
