### PR TITLE
Update to 5.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtconsole" %}
-{% set version = "5.5.0" %}
+{% set version = "5.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/qtconsole-{{ version }}.tar.gz
-  sha256: ea8b4a07d7dc915a1b1238fbfe2c9aea570640402557b64615e09a4bc60df47c
+  sha256: a0e806c6951db9490628e4df80caec9669b65149c7ba40f9bf033c025a5b56bc
 
 build:
   number: 0
@@ -70,7 +70,7 @@ about:
     more.
   doc_url: https://qtconsole.readthedocs.io
   dev_url: https://github.com/jupyter/qtconsole
-  
+
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
qtconsole 5.5.1

**Destination channel:** {defaults}

### Links

- [Upstream repository](https://github.com/jupyter/qtconsole/tree/5.5.1)

### Explanation of changes:

- Updated version and hash