### PR TITLE
Update 5.6.0 -> 5.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtconsole" %}
-{% set version = "5.6.0" %}
+{% set version = "5.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/qtconsole-{{ version }}.tar.gz
-  sha256: 4c82120a3b53a3d36e3f76e6a1a26ffddf4e1ce2359d56a19889c55e1d73a436
+  sha256: 5cad1c7e6c75d3ef8143857fd2ed28062b4b92b933c2cc328252d18a9cfd0be5
 
 build:
   number: 0


### PR DESCRIPTION
qtconsole 5.6.1

**Destination channel:** {defaults}

### Links

- [PKG-6812](https://anaconda.atlassian.net/browse/PKG-6812) 
- [Upstream repository](https://github.com/jupyter/qtconsole)
- [Upstream changelog/diff](https://qtconsole.readthedocs.io/en/stable/)
- Relevant dependency PRs:
  - `spyder 6.0.3`

[PKG-6812]: https://anaconda.atlassian.net/browse/PKG-6812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ