### PR TITLE
qtconsole 5.6.1 (py313 rebuild)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,11 +47,14 @@ test:
     - pip
     - pytest
     - flaky
+    # pyqt 6 fails on linux CI with:
+    # ImportError: libEGL.so.1: cannot open shared object file: No such file or directory
+    # tested locally, works fine
+    - pyqt ==5.*
   source_files:
     - qtconsole/tests
   commands:
     - pip check
-    - export QT_QPA_PLATFORM=offscreen  # [unix]
     # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,9 @@ app:
   type: desk
 
 test:
+  imports:
+    - qtconsole
+    - qtconsole.tests
   requires:
     - pip
     - pytest
@@ -52,12 +55,6 @@ test:
     - qtconsole/tests
   commands:
     - pip check
-    # Add runtime path of libEGL.so.1 so Qt libraries can find it as they're loaded in.
-    # This must be done before the python interpreter starts up.
-    - export LD_LIBRARY_PATH="$PREFIX/x86_64-conda-linux-gnu/sysroot/usr/lib64:${LD_LIBRARY_PATH}"  # [linux and x86_64]
-    - export LD_LIBRARY_PATH="$PREFIX/aarch64-conda-linux-gnu/sysroot/usr/lib64:${LD_LIBRARY_PATH}"  # [linux and aarch64]
-    - python -c "import qtconsole; print('Success')"
-    - python -c "import qtconsole.tests; print('Success')"
     # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
@@ -92,5 +89,3 @@ extra:
     - minrk
     - takluyver
     - ocefpaf
-  skip-lints:
-    - missing_imports_or_run_test_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,10 @@ test:
     - pip
     - pytest
     - flaky
-    - pyqt
+    # pyqt 6 fails on linux CI with:
+    # ImportError: libEGL.so.1: cannot open shared object file: No such file or directory
+    # tested locally, works fine
+    - pyqt ==5.*
   source_files:
     - qtconsole/tests
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,9 +40,6 @@ app:
   type: desk
 
 test:
-  imports:
-    - qtconsole
-    - qtconsole.tests
   requires:
     - pip
     - pytest
@@ -55,6 +52,12 @@ test:
     - qtconsole/tests
   commands:
     - pip check
+    # Add runtime path of libEGL.so.1 so Qt libraries can find it as they're loaded in.
+    # This must be done before the python interpreter starts up.
+    - export LD_LIBRARY_PATH="$PREFIX/x86_64-conda-linux-gnu/sysroot/usr/lib64:${LD_LIBRARY_PATH}"  # [linux and x86_64]
+    - export LD_LIBRARY_PATH="$PREFIX/aarch64-conda-linux-gnu/sysroot/usr/lib64:${LD_LIBRARY_PATH}"  # [linux and aarch64]
+    - python -c "import qtconsole; print('Success')"
+    - python -c "import qtconsole.tests; print('Success')"
     # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.
@@ -89,3 +92,5 @@ extra:
     - minrk
     - takluyver
     - ocefpaf
+  skip-lints:
+    - missing_imports_or_run_test_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - jupyter_core
     - jupyter_client >=4.1
     - pygments
-    - pyqt  # not a dependency listed in setup.py but is still a runtime requirement for qtconsole https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
+    - pyqt ==5.* # not a dependency listed in setup.py but is still a runtime requirement for qtconsole https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
     - qtpy >=2.4.0
     - traitlets !=5.2.1, !=5.2.2  # Skip traitlets versions that break Qtconsole on Windows
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,10 +44,7 @@ test:
     - pip
     - pytest
     - flaky
-    # pyqt 6 fails on linux CI with:
-    # ImportError: libEGL.so.1: cannot open shared object file: No such file or directory
-    # tested locally, works fine
-    - pyqt ==5.*
+    - pyqt
   source_files:
     - qtconsole/tests
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5cad1c7e6c75d3ef8143857fd2ed28062b4b92b933c2cc328252d18a9cfd0be5
 
 build:
-  number: 0
+  number: 1
   # Not available on s390x, ppc64le due to missing qt.
   skip: True  # [py<38 or ppc64le or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - jupyter_core
     - jupyter_client >=4.1
     - pygments
-    - pyqt ==5.* # not a dependency listed in setup.py but is still a runtime requirement for qtconsole https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
+    - pyqt  # not a dependency listed in setup.py but is still a runtime requirement for qtconsole https://qtconsole.readthedocs.io/en/stable/installation.html#installing-qt-if-needed
     - qtpy >=2.4.0
     - traitlets !=5.2.1, !=5.2.2  # Skip traitlets versions that break Qtconsole on Windows
     - packaging
@@ -51,6 +51,7 @@ test:
     - qtconsole/tests
   commands:
     - pip check
+    - export QT_QPA_PLATFORM=offscreen  # [unix]
     # 2022/8/1: Could not find the Qt platform plugin "xcb" in ""
     # This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
     # Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl.


### PR DESCRIPTION
qtconsole 5.6.1 

**Destination channel:** Defaults

### Links

- [PKG-7804]
- dev_url:        https://github.com/jupyter/qtconsole
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- enable py313
- pin pyqt to version 5 in tests (6 works only locally for linux due to CI being headless)


[PKG-7804]: https://anaconda.atlassian.net/browse/PKG-7804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ