### PR TITLE
qtconsole 5.6.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
-


### PR DESCRIPTION
qtconsole 5.6.1 

**Destination channel:** Defaults

### Links

- [PKG-7804]
- dev_url:        https://github.com/jupyter/qtconsole
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- reopening the PR cause last one failed to upload py313 packages for some platforms


[PKG-7804]: https://anaconda.atlassian.net/browse/PKG-7804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ